### PR TITLE
feat: Electron 빌드 시 ad-hoc 서명 설정 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "mac": {
       "category": "public.app-category.productivity",
       "target": "dmg",
-      "icon": "src/assets/icon.png"
+      "icon": "src/assets/icon.png",
+      "identity": null,
+      "type": "development"
     }
   }
 }


### PR DESCRIPTION
- identity를 null로 설정하여 개발자 인증서 없이 서명
- type을 development로 설정하여 개발용 서명 타입 지정

🤖 Generated with [Claude Code](https://claude.ai/code)