### PR TITLE
Bun 실행 경로 문제 해결 및 설치 스크립트 개선

### DIFF
--- a/src/install_script.sh
+++ b/src/install_script.sh
@@ -1,10 +1,46 @@
 #!/bin/bash
 
-# Claude Usage for macOS Quarantine 제거 스크립트
+# Claude Usage for macOS 설치 및 설정 스크립트
 
 APP_NAME="Claude Code Usage Monitor.app"
 INSTALL_PATH="/Applications"
+
+echo "🚀 Bun 설치 중..."
 curl -fsSL https://bun.sh/install | bash
+
+# Bun 환경변수 설정
+echo ""
+echo "⚙️  Bun 환경변수 설정 중..."
+
+# .zshrc에 Bun 환경변수 추가
+ZSHRC="$HOME/.zshrc"
+BUN_ENV_LINES='
+# Bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"'
+
+# 이미 설정되어 있는지 확인
+if ! grep -q "BUN_INSTALL" "$ZSHRC" 2>/dev/null; then
+    echo "$BUN_ENV_LINES" >> "$ZSHRC"
+    echo "✅ ~/.zshrc에 Bun 환경변수를 추가했습니다."
+else
+    echo "ℹ️  Bun 환경변수가 이미 설정되어 있습니다."
+fi
+
+# .bashrc에도 추가 (bash 사용자를 위해)
+BASHRC="$HOME/.bashrc"
+if [ -f "$BASHRC" ]; then
+    if ! grep -q "BUN_INSTALL" "$BASHRC" 2>/dev/null; then
+        echo "$BUN_ENV_LINES" >> "$BASHRC"
+        echo "✅ ~/.bashrc에도 Bun 환경변수를 추가했습니다."
+    fi
+fi
+
+# 현재 세션에도 적용
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+echo ""
 
 
 # 앱이 설치되어 있는지 확인

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, IpcMainEvent } from 'electron';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { execFile } from 'child_process';
+import { exec } from 'child_process';
 import { getBunEnvironment, getCcusageCommand } from './utils.js';
 import { BlockData, UsageUpdateData } from './types.js';
 import { DEFAULT_MAX_TOKEN_LIMIT, UPDATE_INTERVAL, calculateTokenUsage } from './constants.js';
@@ -16,13 +16,9 @@ let maxTokenLimit: number = DEFAULT_MAX_TOKEN_LIMIT;
 const executeCcusageCommand = (subCommand: string, env: NodeJS.ProcessEnv): Promise<any> => {
   return new Promise((resolve, reject) => {
     const fullCommand = getCcusageCommand(subCommand);
-    const parts = fullCommand.split(' ');
-    const cmd = parts[0];
-    const args = parts.slice(1);
 
-    execFile(
-      cmd,
-      args,
+    exec(
+      fullCommand,
       {
         env,
         maxBuffer: 10 * 1024 * 1024,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,38 @@
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 
 export const getBunEnvironment = (): NodeJS.ProcessEnv => {
   const homeDir = os.homedir();
-  const bunPath = path.join(homeDir, '.bun', 'bin');
+  const pathsToAdd: string[] = [];
+
+  // Bun 기본 설치 경로들
+  const bunPaths = [
+    path.join(homeDir, '.bun', 'bin'),
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+    '/opt/homebrew/sbin',
+  ];
+
+  // 존재하는 경로만 추가
+  for (const bunPath of bunPaths) {
+    if (fs.existsSync(bunPath)) {
+      pathsToAdd.push(bunPath);
+    }
+  }
+
+  // 기존 PATH에 새 경로들 추가
+  const existingPath = process.env.PATH || '/usr/bin:/bin';
+  const newPath =
+    pathsToAdd.length > 0
+      ? `${pathsToAdd.join(path.delimiter)}${path.delimiter}${existingPath}`
+      : existingPath;
 
   return {
     ...process.env,
-    PATH: `${bunPath}${path.delimiter}${process.env.PATH || '/usr/bin:/bin'}`,
+    PATH: newPath,
+    // shell을 명시적으로 설정하여 사용자의 기본 shell 환경 활용
+    SHELL: process.env.SHELL || '/bin/bash',
   };
 };
 


### PR DESCRIPTION
## 요약
- 동료 컴퓨터에서 발생한 'spawn bunx ENOENT' 에러 해결
- Bun PATH 자동 탐색 기능 추가
- 설치 스크립트에 환경변수 자동 설정 기능 추가

## 변경사항

### 1. execFile → exec 변경
- `child_process.execFile` 대신 `child_process.exec` 사용
- Shell을 통해 실행되므로 PATH 환경변수를 올바르게 해결
- ~/.zshrc, ~/.bashrc 등의 설정을 활용 가능

### 2. Bun 경로 자동 탐색
- 여러 Bun 설치 경로 확인: `~/.bun/bin`, `/usr/local/bin`, `/opt/homebrew/bin` 등
- 실제 존재하는 경로만 PATH에 추가
- SHELL 환경변수 명시적 설정

### 3. 설치 스크립트 개선
- Bun 설치 후 자동으로 환경변수 설정
- ~/.zshrc와 ~/.bashrc에 BUN_INSTALL과 PATH 추가
- 중복 확인 로직으로 여러 번 실행해도 안전

## 테스트 방법
1. 앱 설치 후 설치 스크립트 실행
2. 터미널 재시작 후 `bun --version` 확인
3. 앱 실행하여 토큰 사용량 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)