### PR TITLE
fix: GitHub Actions 릴리스 권한 문제 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write  # 릴리스 생성 권한 추가
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- permissions: contents: write 추가하여 GITHUB_TOKEN이 릴리스 생성 권한 획득
- 403 Forbidden 에러 해결