### PR TITLE
fix: 자동 업데이트 관련 파일 업로드 방지

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
         "provider": "github",
         "owner": "centraldogma99",
         "repo": "claude-usage-macos",
-        "releaseType": "draft"
+        "releaseType": "draft",
+        "publishAutoUpdate": false
       }
     ]
   }


### PR DESCRIPTION
- publishAutoUpdate: false 설정 추가
- latest-mac.yml과 blockmap 파일 업로드 방지
- DMG 파일만 릴리스에 포함되도록 수정