### PR TITLE
fix: blockmap 파일 생성 완전 방지

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       "identity": null,
       "type": "development"
     },
+    "dmg": {
+      "writeUpdateInfo": false
+    },
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
- dmg.writeUpdateInfo: false 설정 추가
- blockmap 파일 생성 자체를 방지
- 순수 DMG 파일만 생성되도록 설정